### PR TITLE
feat: add rpc client wrapper

### DIFF
--- a/src/common/rpcClient.ts
+++ b/src/common/rpcClient.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'events';
+import { Readable, Writable } from 'stream';
+import { NdjsonLogger } from './logger';
+import { JsonRpcPeer } from './jsonrpc';
+
+export interface SessionUpdateParams {
+  sessionId?: string;
+  sessionUpdate?: string;
+  [key: string]: any;
+}
+
+export interface PermissionRequestMessage {
+  id?: number;
+  params?: {
+    sessionId?: string;
+    title?: string;
+    explanation?: string;
+    operations?: any[];
+  };
+  [key: string]: any;
+}
+
+/**
+ * RpcClient wraps JsonRpcPeer and emits typed events for common notifications.
+ */
+export class RpcClient extends EventEmitter {
+  private peer: JsonRpcPeer;
+
+  constructor(read: Readable, write: Writable, logger: NdjsonLogger) {
+    super();
+    this.peer = new JsonRpcPeer(read, write, logger);
+    this.peer.on('session/update', (params: any) => {
+      this.emit('sessionUpdate', params as SessionUpdateParams);
+    });
+    this.peer.on('session/request_permission', (msg: any) => {
+      this.emit('permissionRequest', msg as PermissionRequestMessage);
+    });
+  }
+
+  request(method: string, params?: any) {
+    return this.peer.request(method, params);
+  }
+
+  notify(method: string, params?: any) {
+    this.peer.notify(method, params);
+  }
+
+  send(obj: any) {
+    this.peer.send(obj);
+  }
+
+  onSessionUpdate(listener: (params: SessionUpdateParams) => void) {
+    this.on('sessionUpdate', listener);
+  }
+
+  onPermissionRequest(listener: (msg: PermissionRequestMessage) => void) {
+    this.on('permissionRequest', listener);
+  }
+}
+

--- a/test/integration/phase7a-ask.test.ts
+++ b/test/integration/phase7a-ask.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn } from 'child_process';
-import { JsonRpcPeer } from '../../src/common/jsonrpc';
+import { RpcClient } from '../../src/common/rpcClient';
 import path from 'path';
 import fs from 'fs/promises';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 describe('Phase 7a - :ask Command Integration Tests', () => {
   let agentProc: any;
-  let peer: JsonRpcPeer;
+  let peer: RpcClient;
   let sessionId: string;
   const testImagePath = path.join(process.cwd(), 'test', 'assets', 'test.jpg');
   const testImageUri = pathToFileURL(testImagePath).href;
@@ -18,7 +18,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
       stdio: ['pipe', 'pipe', 'inherit'],
     });
 
-    peer = new JsonRpcPeer(agentProc.stdout, agentProc.stdin, null as any);
+    peer = new RpcClient(agentProc.stdout, agentProc.stdin, { line: () => {} } as any);
 
     // Initialize
     const initRes = await peer.request('initialize', {
@@ -61,7 +61,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should handle basic :ask command with multiple operations', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId,
@@ -87,7 +87,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should handle clamping and report clamped values', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId,
@@ -106,7 +106,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should handle cumulative behavior across commands', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     // First, reset the stack
     await peer.request('session/prompt', {
@@ -139,7 +139,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should handle amend-last within single command', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     // First, reset the stack
     await peer.request('session/prompt', {
@@ -162,7 +162,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should handle undo/redo/reset commands', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId,
@@ -179,7 +179,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
 
   it('should report ignored terms', async () => {
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId,
@@ -216,7 +216,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
     });
 
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId: offSessionId,
@@ -247,7 +247,7 @@ describe('Phase 7a - :ask Command Integration Tests', () => {
     const noImageSessionId = newRes.sessionId;
 
     const updates: any[] = [];
-    peer.on('session/update', (params) => updates.push(params));
+    peer.onSessionUpdate((params) => updates.push(params));
 
     const result = await peer.request('session/prompt', {
       sessionId: noImageSessionId,

--- a/test/integration/phase7b-gemini.test.ts
+++ b/test/integration/phase7b-gemini.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, ChildProcess } from 'child_process';
-import { JsonRpcPeer } from '../../src/common/jsonrpc';
+import { RpcClient } from '../../src/common/rpcClient';
 import { Readable, Writable } from 'stream';
 import path from 'path';
 import fs from 'fs/promises';
@@ -10,7 +10,7 @@ const SKIP_GEMINI_TESTS = !process.env.GEMINI_API_KEY;
 
 describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () => {
   let agent: ChildProcess;
-  let peer: JsonRpcPeer;
+  let peer: RpcClient;
   let sessionId: string;
   const testImagePath = path.join(process.cwd(), 'test', 'fixtures', 'test.jpg');
 
@@ -29,7 +29,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
       stdio: ['pipe', 'pipe', 'inherit'],
     });
 
-    peer = new JsonRpcPeer(
+    peer = new RpcClient(
       agent.stdout as unknown as Readable,
       agent.stdin as unknown as Writable,
       { line: () => {} } as any
@@ -74,7 +74,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
   it('should handle natural language editing with Gemini', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       updates.push(params);
     });
 
@@ -126,7 +126,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
   it('should clamp extreme values', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       if (params.sessionId === sessionId) {
         updates.push(params);
       }
@@ -157,7 +157,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
   it('should handle export command', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       if (params.sessionId === sessionId) {
         updates.push(params);
       }
@@ -188,7 +188,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
   it('should provide helpful notes about unsupported operations', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       if (params.sessionId === sessionId) {
         updates.push(params);
       }
@@ -220,7 +220,7 @@ describe.skipIf(SKIP_GEMINI_TESTS)('Phase 7b: Gemini Planner Integration', () =>
 
 describe('Phase 7b: Gemini Fallback Behavior', () => {
   let agent: ChildProcess;
-  let peer: JsonRpcPeer;
+  let peer: RpcClient;
   let sessionId: string;
   const testImagePath = path.join(process.cwd(), 'test', 'fixtures', 'test.jpg');
 
@@ -242,7 +242,7 @@ describe('Phase 7b: Gemini Fallback Behavior', () => {
       env,
     });
 
-    peer = new JsonRpcPeer(
+    peer = new RpcClient(
       agent.stdout as unknown as Readable,
       agent.stdin as unknown as Writable,
       { line: () => {} } as any
@@ -290,7 +290,7 @@ describe('Phase 7b: Gemini Fallback Behavior', () => {
   it('should fall back to mock planner when no API key', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       if (params.sessionId === sessionId) {
         updates.push(params);
       }
@@ -323,7 +323,7 @@ describe('Phase 7b: Gemini Fallback Behavior', () => {
 
 describe('Phase 7b: Planner disabled mode', () => {
   let agent: ChildProcess;
-  let peer: JsonRpcPeer;
+  let peer: RpcClient;
   let sessionId: string;
 
   beforeAll(async () => {
@@ -331,7 +331,7 @@ describe('Phase 7b: Planner disabled mode', () => {
       stdio: ['pipe', 'pipe', 'inherit'],
     });
 
-    peer = new JsonRpcPeer(
+    peer = new RpcClient(
       agent.stdout as unknown as Readable,
       agent.stdin as unknown as Writable,
       { line: () => {} } as any
@@ -361,7 +361,7 @@ describe('Phase 7b: Planner disabled mode', () => {
   it('should indicate planner is disabled', async () => {
     const updates: any[] = [];
 
-    peer.on('session/update', (params: any) => {
+    peer.onSessionUpdate((params: any) => {
       if (params.sessionId === sessionId) {
         updates.push(params);
       }


### PR DESCRIPTION
## Summary
- add RpcClient wrapper around JsonRpcPeer that emits typed session and permission events
- refactor client and tests to use RpcClient's typed event helpers

## Testing
- `npm test` *(fails: Phase 7a ask integration, Gemini fallback, coordinate mapping, planner offline, mockPlanner tests, etc.)*
- `npm run format:check` *(fails: Code style issues found in 17 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b6666d922c83339aadff5838cd82b2