### PR TITLE
feat: add thumbnail store

### DIFF
--- a/src/client/thumbnailStore.ts
+++ b/src/client/thumbnailStore.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from 'events';
+
+export interface Thumbnail {
+  metadata?: string;
+  image?: string;
+  mimeType?: string;
+}
+
+export class ThumbnailStore {
+  private store: Map<string, Thumbnail> = new Map();
+  public events = new EventEmitter();
+
+  set(id: string, data: Thumbnail) {
+    const existing = this.store.get(id) || {};
+    const updated = { ...existing, ...data };
+    this.store.set(id, updated);
+    this.events.emit('update', id, updated);
+  }
+
+  get(id: string) {
+    return this.store.get(id);
+  }
+
+  list(): [string, Thumbnail][] {
+    return Array.from(this.store.entries());
+  }
+}


### PR DESCRIPTION
## Summary
- create ThumbnailStore with EventEmitter for thumbnail updates
- refactor photo-client to use ThumbnailStore instead of Map

## Testing
- `npm test` *(fails: expected [ Array(1) ] to include 'Clamped values', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b66675a7b483339b51f7a22a4d70ff